### PR TITLE
Make A3 chop floor configurable + add kill switch

### DIFF
--- a/llm_reports/refactors/2026-05-25_configurable-chop-floor.md
+++ b/llm_reports/refactors/2026-05-25_configurable-chop-floor.md
@@ -1,0 +1,113 @@
+---
+type: refactor
+date: 2026-05-25
+time: 19:50 UTC
+agent: Claude Opus 4.7
+model: claude-opus-4-7
+trigger: User asked to make A3 chop floor runtime-tunable while the training/inference asymmetry stays open
+head: 82dbdba (main tip at branch creation)
+scope: modifies-source
+related:
+  - refactors/2026-05-23_lightgbm-hmm-pilot.md
+  - audits/2026-05-24_lightgbm-pilot-soak-readiness.md
+files_touched:
+  - src/execution/risk_manager.py
+---
+
+# Configurable A3 chop floor + kill switch
+
+## Context
+
+The A3 chop filter at `src/execution/risk_manager.py:54` vetoes any
+signal whose ATR-derived SL distance falls below a hardcoded floor.
+Recent work made the floor asset-class-aware (2.0 pips for forex via
+`RiskProfile.for_asset_class("forex")`, 0.15% for equities), but the
+floor values were still compile-time constants.
+
+The deeper issue is a **training/inference asymmetry**: the retrainer
+does not simulate this filter during bracket-target generation, so the
+Devil's PF 2.22 was learned on the full Angel-approved population
+including bars the runtime filter would have vetoed. Yesterday's commit
+`82dbdba` added a counter on `OandaScalperOrchestrator` to measure how
+often this happens in practice; the soak's chop-veto rate over the
+first week will decide whether the asymmetry is academic (< 1%) or
+load-bearing (> 5%).
+
+This change is the **operational counterpart** to that telemetry work:
+expose the floor and a kill switch as env vars so the operator can
+tune the filter in production without code edits, and so the soak can
+be re-run with the filter disabled if needed to A/B test live PF
+against the unfiltered training distribution.
+
+**This does NOT close the asymmetry.** Closing it requires changing
+the retrainer's training-set selection logic, which is a larger change
+with a full retrain + gate evaluation downstream. That work is
+deferred until the soak's chop-counter data tells us if the asymmetry
+is actually biting hard enough to justify it.
+
+## Findings / Changes
+
+### Change 1 — Env vars on `RiskProfile.for_asset_class`
+
+`src/execution/risk_manager.py` exports three new env var names at
+module scope so they're discoverable:
+
+```python
+ENV_FOREX_MIN_SL_PIPS    = "RISK_FOREX_MIN_SL_PIPS"
+ENV_EQUITIES_MIN_SL_PCT  = "RISK_EQUITIES_MIN_SL_PCT"
+ENV_CHOP_FILTER_ENABLED  = "RISK_CHOP_FILTER_ENABLED"
+```
+
+`for_asset_class` reads the appropriate env var per branch with the
+prior hardcoded value as the default fallback. Behavior with no env
+vars set is identical to before this change.
+
+### Change 2 — Kill switch in `calculate_bracket`
+
+When `_chop_filter_enabled()` returns False (env var in
+`0|false|no|off`), the floor comparison still computes but the
+rejection is suppressed — the bracket is returned and the trade
+proceeds. The would-have-vetoed condition is logged so operators can
+still see how often the filter *would* have triggered while it's
+disabled.
+
+When the filter is enabled (default), the rejection log line now
+includes the actual `sl_dist`, the active `floor`, and the shortfall —
+useful diagnostic granularity beyond the orchestrator-side counter.
+
+## Verification
+
+```
+default forex min_sl_pips=2.0                  ✓ matches prior hardcoded
+default equities min_sl_pct=0.0015             ✓ matches prior hardcoded
+RISK_FOREX_MIN_SL_PIPS=1.5    → min_sl_pips=1.5     ✓ override works
+RISK_EQUITIES_MIN_SL_PCT=0.001 → min_sl_pct=0.001    ✓ override works
+RISK_CHOP_FILTER_ENABLED unset, tiny sl_dist  → None (rejected)
+RISK_CHOP_FILTER_ENABLED=0,    tiny sl_dist   → (sl, tp) (passed)
+```
+
+All truthy variants resolve correctly:
+- Falsy: `0`, `false`, `False`, `no`, `off`
+- Truthy: `1`, `true`, `yes`, `on`, `""` (unset), or any other value
+
+## Risk & follow-ups
+
+- **Training/inference asymmetry remains open.** This change exposes
+  the runtime knob; it does not align the retrainer with the runtime
+  filter. The Devil still learns on a slightly different population
+  than it will face live.
+- **Soak data informs the next step.** If commit `82dbdba`'s counter
+  shows the chop filter biting < 1% of approvals through Friday's
+  check-in, the asymmetry is academic and no further work is needed.
+  If > 5%, the retrainer-side fix becomes mandatory before any
+  real-money promotion.
+- **No `.env.example` updated.** This repo doesn't have one (`.env`
+  is in `.gitignore` and there's no template). New operators should
+  consult this report or `src/execution/risk_manager.py` for the env
+  var names.
+
+## Files touched
+
+- `src/execution/risk_manager.py` — added env var imports +
+  `_chop_filter_enabled()` helper + plumbing in
+  `RiskProfile.for_asset_class` and `RiskManager.calculate_bracket`.

--- a/src/execution/oanda_scalper_orchestrator.py
+++ b/src/execution/oanda_scalper_orchestrator.py
@@ -104,6 +104,14 @@ class OandaScalperOrchestrator:
         # Discord webhook (silently no-ops when DISCORD_WEBHOOK_URL unset)
         self._notifier = NotificationManager()
 
+        # A3 chop-filter telemetry: track how often the RiskManager's chop
+        # filter vetoes a Devil-approved signal. The retrainer does NOT
+        # simulate this filter during target generation, so a high veto
+        # rate indicates a training/inference asymmetry that needs closing
+        # before the model can be trusted with real money.
+        self._devil_approved_total: int = 0
+        self._a3_chop_rejections: int = 0
+
     # ── tick callback (runs on provider's blocking stream thread) ─────
 
     def _on_tick(self, symbol: str, bid: float, ask: float) -> None:
@@ -241,6 +249,9 @@ class OandaScalperOrchestrator:
         if signal is None:
             return
 
+        # Devil approved this signal. Track it for A3 chop-filter telemetry.
+        self._devil_approved_total += 1
+
         # ── guard: do not trade while a close is pending ──
         with self._positions_lock:
             existing = self._positions.get(symbol)
@@ -268,9 +279,15 @@ class OandaScalperOrchestrator:
                     tp_price = signal.entry_price - tp_dist
 
         if sl_price is None or tp_price is None:
+            self._a3_chop_rejections += 1
+            ratio = 100.0 * self._a3_chop_rejections / max(self._devil_approved_total, 1)
             logger.warning(
-                "[%s] Bracket calculation rejected trade (A3 chop filter)",
+                "[%s] Bracket calculation rejected trade (A3 chop filter) | "
+                "running: %d / %d Devil-approved vetoed (%.1f%%)",
                 symbol,
+                self._a3_chop_rejections,
+                self._devil_approved_total,
+                ratio,
             )
             return
 

--- a/src/execution/risk_manager.py
+++ b/src/execution/risk_manager.py
@@ -1,8 +1,25 @@
 import logging
+import os
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+# Environment variables for tuning the A3 chop filter without code changes.
+# The retrainer does not simulate this filter during target generation, so
+# a high veto rate is a training/inference asymmetry; these knobs let us
+# tune the floor (or disable it) per environment while the asymmetry stays
+# open. See llm_reports/refactors/2026-05-25_configurable-chop-floor.md.
+ENV_FOREX_MIN_SL_PIPS = "RISK_FOREX_MIN_SL_PIPS"
+ENV_EQUITIES_MIN_SL_PCT = "RISK_EQUITIES_MIN_SL_PCT"
+ENV_CHOP_FILTER_ENABLED = "RISK_CHOP_FILTER_ENABLED"
+
+
+def _chop_filter_enabled() -> bool:
+    """RISK_CHOP_FILTER_ENABLED toggles the floor. Unset / 1 / true enables."""
+    raw = os.getenv(ENV_CHOP_FILTER_ENABLED, "1").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
 
 @dataclass
 class RiskProfile:
@@ -20,10 +37,12 @@ class RiskProfile:
             return cls(
                 sl_atr_multiplier=1.0,
                 tp_atr_multiplier=2.0,
-                min_sl_pips=2.0,
+                min_sl_pips=float(os.getenv(ENV_FOREX_MIN_SL_PIPS, "2.0")),
                 round_precision=5,
             )
-        return cls()
+        return cls(
+            min_sl_pct=float(os.getenv(ENV_EQUITIES_MIN_SL_PCT, "0.0015")),
+        )
 
 class RiskManager:
     """
@@ -51,9 +70,27 @@ class RiskManager:
         else:
             floor = entry_price * self.profile.min_sl_pct
 
-        # A3 chop filter: if the stop floor would override the ATR stop, skip entirely
+        # A3 chop filter: if the stop floor would override the ATR stop, skip
+        # entirely. RISK_CHOP_FILTER_ENABLED=0 disables the gate (useful for
+        # comparing live PF against the unfiltered training distribution).
         if sl_dist < floor:
-            return None
+            if _chop_filter_enabled():
+                logger.info(
+                    "[%s] A3 chop filter veto: sl_dist=%.6f < floor=%.6f "
+                    "(shortfall=%.6f)",
+                    symbol or "unknown",
+                    sl_dist,
+                    floor,
+                    floor - sl_dist,
+                )
+                return None
+            logger.info(
+                "[%s] A3 chop filter DISABLED (would have vetoed: "
+                "sl_dist=%.6f < floor=%.6f)",
+                symbol or "unknown",
+                sl_dist,
+                floor,
+            )
 
         return round(sl_dist, self.profile.round_precision), round(tp_dist, self.profile.round_precision)
 


### PR DESCRIPTION
  ## Summary
  - Exposes three env vars on `RiskProfile` / `RiskManager` so the chop-filter floor can be tuned (or disabled) in production without code changes: `RISK_FOREX_MIN_SL_PIPS` (default 2.0), `RISK_EQUITIES_MIN_SL_PCT` (default 0.0015),
  `RISK_CHOP_FILTER_ENABLED` (default 1).
  - Default behavior is identical to before — all defaults match the prior hardcoded values. The kill switch is the headline feature: setting `RISK_CHOP_FILTER_ENABLED=0` lets the soak run unfiltered so we can A/B compare live PF against
  the unfiltered training distribution if commit `82dbdba`'s rejection-counter turns out load-bearing.
  - Rejection log line now includes `sl_dist`, `floor`, and `shortfall` for diagnostic granularity beyond the orchestrator-side counter.

  **Does NOT close the training/inference asymmetry.** The retrainer still trains the Devil on the full Angel-approved population including bars the filter would veto live. That fix is deferred — Friday's soak check-in tells us if veto
  rate justifies the larger work.

  Full report: `llm_reports/refactors/2026-05-25_configurable-chop-floor.md`

  ## Test plan
  - [ ] `git pull` on the soak machine, no restart needed for env-var defaults (behavior unchanged)
  - [ ] Verify in the running soak that the new log shape appears next time the filter trips: `[SYMBOL] A3 chop filter veto: sl_dist=X.XXXXXX < floor=Y.YYYYYY (shortfall=Z.ZZZZZZ)`
  - [ ] (Optional) Restart with `RISK_CHOP_FILTER_ENABLED=0` for an experimental window if you want to see what gets through; the "would have vetoed" log lines tell you what the floor *would* have rejected
  - [ ] Friday check-in routine pulls the counter ratio and decides whether to escalate to the training-side fix

  🤖 Generated with [Claude Code](https://claude.com/claude-code)